### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Build latest version and publish to GitHub Registry
-        uses: elgohr/Publish-Docker-Github-Action@3.04
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: mileschou/gitdags
           tags: latest


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore